### PR TITLE
Add README token test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Validação de usuário retornando um token válido
 
 Validação do token gerado para acessar um recurso de teste
 
+Testando a validação do token
+=============================
+
+Para testar se o token é aceito pela aplicação acesse o endpoint `/testetoken`
+enviando o cabeçalho `Authorization: Bearer <token>`.
+
+Exemplo de requisição:
+
+```
+curl -H "Authorization: Bearer <token>" http://localhost:3000/testetoken
+```
+
 
 Falta fazer
 


### PR DESCRIPTION
## Summary
- document how to validate a token using `/testetoken`
- show a simple request example

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68408b1c3f3c832c8a3e73138b38032f