### PR TITLE
Fix auth middleware parts length check

### DIFF
--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -11,7 +11,7 @@ module.exports = (req, res, next) => {
 
     const parts = authHeader.split(' ');
 
-    if (!parts.lenght === 2){
+    if (!parts.length === 2){
         res.status(401).send ( { error: 'Token error'});
     };
 


### PR DESCRIPTION
## Summary
- fix `parts.length` typo in auth middleware

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68408b066ac8832c97fd62607a9fb9d7