### PR TITLE
Implement password reset workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Validação de usuário retornando um token válido
 
 Validação do token gerado para acessar um recurso de teste
 
+Recuperação de senha enviando token por e-mail
+
 Testando a validação do token
 =============================
 

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
+const crypto = require('crypto');
 
 const authConfig = require('../config/auth');
 
-const User = require('../models/User');
+const User = require('../models/user');
+const emailUtil = require('../utils/email');
 
 const router = express.Router();
 
@@ -56,6 +58,66 @@ router.post('/authenticate', async (req, res) => {
 
     res.send( { user, token });
 
+});
+
+router.post('/forgot_password', async (req, res) => {
+    const { email } = req.body;
+
+    try {
+        const user = await User.findOne({ email });
+
+        if (!user) {
+            return res.status(400).send({ error: 'User not found' });
+        }
+
+        const token = crypto.randomBytes(4).toString('hex');
+        const now = new Date();
+        now.setHours(now.getHours() + 1);
+
+        await User.findByIdAndUpdate(user.id, {
+            '$set': {
+                passwordResetToken: token,
+                passwordResetExpires: now
+            }
+        });
+
+        await emailUtil.sendResetPasswordMail(email, token);
+
+        return res.send();
+    } catch (err) {
+        return res.status(400).send({ error: 'Error on forgot password, try again' });
+    }
+});
+
+router.post('/reset_password', async (req, res) => {
+    const { email, token, password } = req.body;
+
+    try {
+        const user = await User.findOne({ email })
+            .select('+passwordResetToken passwordResetExpires');
+
+        if (!user) {
+            return res.status(400).send({ error: 'User not found' });
+        }
+
+        if (token !== user.passwordResetToken) {
+            return res.status(400).send({ error: 'Token invalid' });
+        }
+
+        if (new Date() > user.passwordResetExpires) {
+            return res.status(400).send({ error: 'Token expired, generate a new one' });
+        }
+
+        user.password = password;
+        user.passwordResetToken = undefined;
+        user.passwordResetExpires = undefined;
+
+        await user.save();
+
+        return res.send();
+    } catch (err) {
+        return res.status(400).send({ error: 'Cannot reset password, try again' });
+    }
 });
 
 module.exports = app => app.use('/auth', router);

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -17,6 +17,14 @@ const UserSchema = new mongoose.Schema({
         require: true,
         select: false,
     },
+    passwordResetToken: {
+        type: String,
+        select: false,
+    },
+    passwordResetExpires: {
+        type: Date,
+        select: false,
+    },
     createAt: {
         type: Date,
         default: Date.now,

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -1,0 +1,6 @@
+module.exports = {
+    async sendResetPasswordMail(to, token) {
+        // TODO: configure real email service
+        console.log(`Send reset password token to ${to}: ${token}`);
+    }
+};


### PR DESCRIPTION
## Summary
- add forgot/reset password endpoints in auth controller
- extend user model with password reset fields
- document password recovery feature in README
- stub email utility for sending reset tokens

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: no tests configured)*
- `node src/index.js` *(fails: MongoDB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed9a0bf8832c8d7192e88e26f5dd